### PR TITLE
Use Postgres 16 (latest stable)

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12 as db
+FROM postgres:16 as db
 WORKDIR /app
 COPY init.sh /docker-entrypoint-initdb.d
 COPY dump.sql ./scripts/db/dump.sql


### PR DESCRIPTION
I noticed during a demo that we were using PG 12. It worked fine but technically not a version we support. Switching to latest.